### PR TITLE
New feature: copy the content of a screen region

### DIFF
--- a/examples/src/main/java/org/sikuli/api/examples/CopyRegionExample.java
+++ b/examples/src/main/java/org/sikuli/api/examples/CopyRegionExample.java
@@ -1,0 +1,48 @@
+/**
+Khalid
+*/
+package org.sikuli.api.examples;
+
+import static org.sikuli.api.API.browse;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.sikuli.api.DesktopScreenRegion;
+import org.sikuli.api.ImageTarget;
+import org.sikuli.api.Relative;
+import org.sikuli.api.ScreenRegion;
+import org.sikuli.api.Target;
+import org.sikuli.api.robot.Keyboard;
+import org.sikuli.api.robot.desktop.DesktopKeyboard;
+import org.sikuli.api.visual.Canvas;
+import org.sikuli.api.visual.DesktopCanvas;
+
+public class CopyRegionExample {
+	public static void main(String[] args) throws MalformedURLException{
+		// Open the main page of Google Code in the default web browser
+		browse(new URL("http://code.google.com"));
+		
+		// Create a screen region object that corresponds to the default monitor in full screen
+		ScreenRegion s = new DesktopScreenRegion();
+		
+		// Specify an image as the target to find on the screen
+		URL imageURL = new URL("http://code.google.com/images/code_logo.gif");
+		Target imageTarget = new ImageTarget(imageURL);
+		
+		// Wait for the target to become visible on the screen for at most 5 seconds
+		ScreenRegion r = s.wait(imageTarget,5000);
+		
+		// Specify the region to be copied
+		ScreenRegion copyRegion = Relative.to(r).right(310).below(20).above(10).getScreenRegion();
+		
+		// Display canvas next to the region to be copied for 3 seconds
+		Canvas canvas = new DesktopCanvas();
+		canvas.addLabel(copyRegion, "region to be copied.");
+		canvas.display(3);
+		
+		// copy the content of the region
+		Keyboard keyboard = new DesktopKeyboard();
+		keyboard.copyRegion(copyRegion);
+	}
+}

--- a/examples/src/main/java/org/sikuli/api/examples/CopyRegionExample.java
+++ b/examples/src/main/java/org/sikuli/api/examples/CopyRegionExample.java
@@ -1,13 +1,8 @@
-/**
-Khalid
-*/
 package org.sikuli.api.examples;
 
 import static org.sikuli.api.API.browse;
-
 import java.net.MalformedURLException;
 import java.net.URL;
-
 import org.sikuli.api.DesktopScreenRegion;
 import org.sikuli.api.ImageTarget;
 import org.sikuli.api.Relative;
@@ -36,8 +31,9 @@ public class CopyRegionExample {
 		// Specify the region to be copied
 		ScreenRegion copyRegion = Relative.to(r).right(310).below(20).above(10).getScreenRegion();
 		
-		// Display canvas next to the region to be copied for 3 seconds
+		// Display canvas on the region to be copied for 3 seconds
 		Canvas canvas = new DesktopCanvas();
+		canvas.addBox(copyRegion);
 		canvas.addLabel(copyRegion, "region to be copied.");
 		canvas.display(3);
 		

--- a/src/main/java/org/sikuli/api/DefaultScreenRegion.java
+++ b/src/main/java/org/sikuli/api/DefaultScreenRegion.java
@@ -146,6 +146,26 @@ public class DefaultScreenRegion extends AbstractScreenRegion implements ScreenR
 			lastCapturedImage = capture();
 		return lastCapturedImage;
 	}
+	
+	@Override
+	public ScreenLocation getUpperLeftCorner() {
+		return new DefaultScreenLocation(getScreen(), getX(), getY());
+	}
+	
+	@Override
+	public ScreenLocation getLowerLeftCorner() {
+		return new DefaultScreenLocation(getScreen(), getX(), getY() + getHeight());
+	}
+	
+	@Override
+	public ScreenLocation getUpperRightCorner() {
+		return new DefaultScreenLocation(getScreen(), getX() + getWidth(), getY());
+	}
+	
+	@Override
+	public ScreenLocation getLowerRightCorner() {
+		return new DefaultScreenLocation(getScreen(), getX() + getWidth(), getY() + getHeight());
+	}
 
 	@Override
 	public ScreenLocation getCenter() {

--- a/src/main/java/org/sikuli/api/DesktopScreenRegion.java
+++ b/src/main/java/org/sikuli/api/DesktopScreenRegion.java
@@ -35,5 +35,23 @@ public class DesktopScreenRegion extends DefaultScreenRegion implements ScreenRe
 			this.setScreen(_screen);
 		}
 	}
+	
+	/**
+	 * Create a screen region based on X, Y, width and height.
+	 * The related screen will be determined automatically based on the
+	 * center of the rectangle and default to the given screen id in case the center is
+	 * outside of all available screens.
+	 */
+	public DesktopScreenRegion(int id, int x, int y, int width, int height) {
+		super(new DesktopScreen(id));
+		setX(x);
+		setY(y);
+		setWidth(width);
+		setHeight(height);
+		DesktopScreen _screen= DesktopScreen.getScreenAtCoord(x+width/2,y+height/2);
+		if (_screen!=null) {
+			this.setScreen(_screen);
+		}
+	}
 		
 }

--- a/src/main/java/org/sikuli/api/ScreenRegion.java
+++ b/src/main/java/org/sikuli/api/ScreenRegion.java
@@ -19,6 +19,34 @@ public interface ScreenRegion {
 
 	public ScreenRegion getRelativeScreenRegion(int xoffset, int yoffset, int width, int height);
 	public ScreenLocation getRelativeScreenLocation(int xoffset, int yoffset);
+	
+	/**
+	 * Gets the upper-left corner of this screen region
+	 * 
+	 * @return a Location object corresponding to the upper-left corner of the screen region
+	 */
+	public abstract ScreenLocation getUpperLeftCorner();
+	
+	/**
+	 * Gets the lower-left corner of this screen region
+	 * 
+	 * @return a Location object corresponding to the lower-left corner of the screen region
+	 */
+	public abstract ScreenLocation getLowerLeftCorner();
+	
+	/**
+	 * Gets the upper-right corner of this screen region
+	 * 
+	 * @return a Location object corresponding to the upper-right corner of the screen region
+	 */
+	public abstract ScreenLocation getUpperRightCorner();
+	
+	/**
+	 * Gets the lower-right corner of this screen region
+	 * 
+	 * @return a Location object corresponding to the lower-right corner of the screen region
+	 */
+	public abstract ScreenLocation getLowerRightCorner();
 
 	/**
 	 * Gets the center of this screen region 

--- a/src/main/java/org/sikuli/api/robot/Keyboard.java
+++ b/src/main/java/org/sikuli/api/robot/Keyboard.java
@@ -1,5 +1,7 @@
 package org.sikuli.api.robot;
 
+import org.sikuli.api.ScreenRegion;
+
 public interface Keyboard {
 	
 	/**
@@ -11,6 +13,14 @@ public interface Keyboard {
 	 * @return The clipboard contents converted to a String or <code>null</code>
 	 */
 	public String copy();
+	
+	/**
+	 * Copies the content of a screen region into the clipboard. It highlights the content of the given 
+	 * screen region by clicking on its upper-left corner and moving the mouse to the lower-right corner, 
+	 * then it performs the keyboard shortcut to copy the content of the screen region.
+	 * @param screenRegion The screen region to be copied
+	 */
+	public void copyRegion(ScreenRegion screenRegion);
 	
 	public void paste(String text);
 	public void type(String text);

--- a/src/main/java/org/sikuli/api/robot/desktop/DesktopKeyboard.java
+++ b/src/main/java/org/sikuli/api/robot/desktop/DesktopKeyboard.java
@@ -5,8 +5,11 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.awt.event.KeyEvent;
 
 import org.sikuli.api.APILogger;
+import org.sikuli.api.ScreenLocation;
+import org.sikuli.api.ScreenRegion;
 import org.sikuli.api.robot.Env;
 import org.sikuli.api.robot.Keyboard;
+import org.sikuli.api.robot.Mouse;
 
 
 public class DesktopKeyboard implements Keyboard {
@@ -32,7 +35,17 @@ public class DesktopKeyboard implements Keyboard {
 		APILogger.getLogger().copyPerformed(text);
 		return text;
 	}
-
+	
+	public void copyRegion(ScreenRegion screenRegion){
+		Mouse mouse = new DesktopMouse();
+		ScreenLocation start = screenRegion.getUpperLeftCorner();
+		ScreenLocation end = screenRegion.getLowerRightCorner();
+		mouse.move(start);
+		mouse.press();
+		mouse.move(end);
+		copy();
+		mouse.release();
+	}
 	
 	public void paste(String text){
 		checkNotNull(text);


### PR DESCRIPTION
This pull request includes: 

<ul>
<li>A new method (copyRegion) to copy the content of a screen region.</li>
<li>An example on how to use copyRegion method</li>
<li>New methods to get the four corners of a screen region</li>
<li>A new method to create a custom screen region on a given screen/monitor</li>
</ul>
